### PR TITLE
style: optimize for mobile

### DIFF
--- a/app/components/route-page/role-skill-selects.tsx
+++ b/app/components/route-page/role-skill-selects.tsx
@@ -36,7 +36,7 @@ export default function RoleSkillSelects(props: RoleSkillSelectsProps) {
     if (pdtSkill) {
       Object.entries(pdtSkill).map(([pdt, percent]) => {
         texts.push(
-          <span key={`roleskilltext-pdt-${pdt}`} className="mx-auto block text-center pt-1">
+          <span key={`roleskilltext-pdt-${pdt}`} className="mx-auto block text-center pt-1 max-sm:min-w-24">
             {pdt}+{percent}%
           </span>
         );
@@ -47,7 +47,7 @@ export default function RoleSkillSelects(props: RoleSkillSelectsProps) {
     if (citySkill) {
       Object.entries(citySkill).map(([city, percent]) => {
         texts.push(
-          <span key={`roleskilltext-city-${city}`} className="mx-auto block text-center pt-1">
+          <span key={`roleskilltext-city-${city}`} className="mx-auto block text-center pt-1 max-sm:min-w-24">
             {city}特产+{percent}%
           </span>
         );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,8 +8,9 @@ import { env } from "process";
 import Header from "./components/header/header";
 import "./globals.css";
 import PriceProvider from "./price-provider";
+import type { Metadata, Viewport } from "next";
 
-export const metadata = {
+export const metadata: Metadata = {
   title: "科伦巴商会",
   description: "雷索纳斯 科伦巴商会 数据分享站",
 
@@ -17,6 +18,17 @@ export const metadata = {
   alternates: {
     canonical: "/",
   },
+};
+
+// Prevent automatic scale when focusing input (these will not affect the PC)
+export const viewport: Viewport = {
+  initialScale: 1,
+  minimumScale: 1,
+  maximumScale: 1,
+  width: "device-width",
+  // I think it's better to prevent scaling on mobile because there's nothing worth scaling on the website.
+  // However, this is not work for iOS. It can only be solved by js, so forget it.
+  userScalable: false,
 };
 
 const inter = Noto_Sans_SC({

--- a/app/route/page.tsx
+++ b/app/route/page.tsx
@@ -208,7 +208,7 @@ export default function RoutePage() {
 
         {/* 一图流 */}
         <div role="tabpanel" hidden={tabIndex !== 0}>
-          <div className="bg-white dark:bg-gray-800 p-6 shadow-xl ring-1 ring-gray-900/5 rounded-lg backdrop-blur-lg max-w-2xl mx-auto my-4 w-full">
+          <div className="bg-white dark:bg-gray-800 p-6 shadow-xl ring-1 ring-gray-900/5 rounded-lg backdrop-blur-lg max-w-2xl mx-auto my-4 w-full box-border">
             <div className="flex flex-col">
               <Typography>
                 <Typography component="strong" fontSize={18}>
@@ -433,7 +433,7 @@ export default function RoutePage() {
 
         {/* 个性化设置 */}
         <div role="tabpanel" hidden={tabIndex !== 1}>
-          <div className="bg-white dark:bg-gray-800 p-6 shadow-xl ring-1 ring-gray-900/5 rounded-lg backdrop-blur-lg max-w-4xl mx-auto my-4 w-full">
+          <div className="bg-white dark:bg-gray-800 p-6 max-sm:px-0 shadow-xl ring-1 ring-gray-900/5 rounded-lg backdrop-blur-lg max-w-4xl mx-auto my-4 w-full box-border">
             <Box
               className="m-4"
               sx={{
@@ -502,7 +502,7 @@ export default function RoutePage() {
               </Box>
 
               <Typography>乘员共振</Typography>
-              <Box className="m-4">
+              <Box className="m-4 max-sm:mx-0">
                 <RoleSkillSelects playerConfig={playerConfig} setRoleResonance={setRoleResonance} />
               </Box>
             </Box>
@@ -511,7 +511,7 @@ export default function RoutePage() {
 
         {/* 最优线路详细信息 */}
         <div role="tabpanel" hidden={tabIndex !== 2}>
-          <div className="bg-white dark:bg-gray-800 p-6 shadow-xl ring-1 ring-gray-900/5 rounded-lg backdrop-blur-lg max-w-2xl mx-auto my-4 w-full">
+          <div className="bg-white dark:bg-gray-800 p-6 shadow-xl ring-1 ring-gray-900/5 rounded-lg backdrop-blur-lg max-w-2xl mx-auto my-4 w-full box-border">
             <div className="flex justify-between items-center mb-4">
               <Typography component="h3">
                 选择一个起始城市查看从这个城市出发的最优线路，或选择 任意 查看整体最优线路。
@@ -554,7 +554,7 @@ export default function RoutePage() {
                 exchangesCombination.length > 0 && (
                   <Box key={`recomendation-${index}`} className="m-4">
                     <Typography>购买{detailedRecommendations.length - index}种商品</Typography>
-                    <Box className="m-4">
+                    <Box className="m-4 max-sm:mx-0">
                       <TableContainer component={Paper}>
                         <Table sx={{ minWidth: 650 }} aria-label="simple table">
                           <TableHead>
@@ -604,7 +604,7 @@ export default function RoutePage() {
 
         {/* 详细模拟 */}
         <div role="tabpanel" hidden={tabIndex !== 3}>
-          <div className="bg-white dark:bg-gray-800 p-6 shadow-xl ring-1 ring-gray-900/5 rounded-lg backdrop-blur-lg max-w-2xl mx-auto my-4 w-full">
+          <div className="bg-white dark:bg-gray-800 p-6 shadow-xl ring-1 ring-gray-900/5 rounded-lg backdrop-blur-lg max-w-2xl mx-auto my-4 w-full box-border">
             <div className="flex justify-between items-center mb-4">
               <Typography component="h3">选择一个或多个起始城市以及终点城市，查看所有线路以及最优交易组合。</Typography>
             </div>
@@ -646,7 +646,7 @@ export default function RoutePage() {
                   return (
                     <div
                       key={`table-${fromCity}-${toCity}`}
-                      className="p-2 shadow-xl ring-1 ring-gray-900/5 rounded-lg backdrop-blur-lg max-w-5xl mx-auto my-2 w-full"
+                      className="p-2 shadow-xl ring-1 ring-gray-900/5 rounded-lg backdrop-blur-lg max-w-5xl mx-auto my-2 w-full box-border"
                     >
                       <Typography className="my-4">
                         {fromCity}
@@ -705,7 +705,7 @@ export default function RoutePage() {
 
         {/* 计算说明 */}
         <div role="tabpanel" hidden={tabIndex !== 4}>
-          <div className="bg-white dark:bg-gray-800 p-6 shadow-xl ring-1 ring-gray-900/5 rounded-lg backdrop-blur-lg max-w-2xl mx-auto my-4 w-full">
+          <div className="bg-white dark:bg-gray-800 p-6 shadow-xl ring-1 ring-gray-900/5 rounded-lg backdrop-blur-lg max-w-2xl mx-auto my-4 w-full box-border">
             <div className="flex flex-col">
               <Typography>买价为砍价税后价格。</Typography>
               <Typography>卖价为抬价后价格。</Typography>


### PR DESCRIPTION
为移动端优化样式

1. 修复了一些 div 会溢出的问题
2. 在小屏幕下移除了一些不必要的边距，能显示更多内容
3. 在小屏幕下优化了一下天赋表格的文字显示
4. 避免移动端聚焦输入框时自动放大页面

<details>

| Before | After |
|---|---|
| ![IMG_8472](https://github.com/NathanKun/resonance-columba/assets/24877906/6128b6eb-0026-48c0-aa35-94396f8beebe) | ![IMG_8478](https://github.com/NathanKun/resonance-columba/assets/24877906/bf729a71-4add-494c-8452-6399443822c0) |
| ![IMG_8473](https://github.com/NathanKun/resonance-columba/assets/24877906/db14a57b-8599-4431-945e-97020f40c942) | ![IMG_8479](https://github.com/NathanKun/resonance-columba/assets/24877906/532255d9-ef8f-4c16-a539-d769ce9d309c) |
| ![IMG_8474](https://github.com/NathanKun/resonance-columba/assets/24877906/2997058a-d0fe-4f6c-9b62-3abdcf4da733) | ![IMG_8485](https://github.com/NathanKun/resonance-columba/assets/24877906/ca5011b7-86bf-4f36-86c9-95462ece8542) |
| ![IMG_8475](https://github.com/NathanKun/resonance-columba/assets/24877906/7b620e6b-1d3d-423a-810e-d11bfd1a2d22) | ![IMG_8481](https://github.com/NathanKun/resonance-columba/assets/24877906/64745e24-9eac-46ec-9466-a42a4ea6cbc1) |
| ![IMG_8476](https://github.com/NathanKun/resonance-columba/assets/24877906/12573caf-d03d-4360-9690-c375e3ea415f) | ![IMG_8482](https://github.com/NathanKun/resonance-columba/assets/24877906/b71ad563-757c-42a6-be55-e38add03acd3) |
| ![IMG_8477](https://github.com/NathanKun/resonance-columba/assets/24877906/1fafe808-4bbf-4249-8d91-db29bc45cace) | ![IMG_8483](https://github.com/NathanKun/resonance-columba/assets/24877906/0d8c4e0a-d2da-483d-bcad-528882c07148) |
</details>
