### PR TITLE
feat: enhance restock slider experience

### DIFF
--- a/app/components/route-page/number-input.tsx
+++ b/app/components/route-page/number-input.tsx
@@ -1,4 +1,4 @@
-import { OutlinedInputProps, TextField } from "@mui/material";
+import { TextField, TextFieldProps } from "@mui/material";
 import { useEffect, useState } from "react";
 
 type VALUE_TYPE = number | undefined;
@@ -43,7 +43,9 @@ const constrainedValue = (value: VALUE_TYPE, min: VALUE_TYPE, max: VALUE_TYPE): 
 };
 
 type Props = {
-  label: string;
+  label?: string;
+  hiddenLabel?: TextFieldProps["hiddenLabel"];
+  variant?: TextFieldProps["variant"];
   value: VALUE_TYPE;
   min: number;
   max: number;
@@ -51,13 +53,30 @@ type Props = {
   defaultValue: number;
   type: "integer" | "float";
   decimalPlaces?: number;
-  InputProps?: Partial<OutlinedInputProps>;
+  InputProps?: TextFieldProps["InputProps"];
+  inputProps?: TextFieldProps["inputProps"];
   className?: string;
+  hideSpinButton?: boolean;
   setValue: (value: number, event: any) => void;
 };
 
 export default function NumberInput(props: Props) {
-  const { type, value, label, min, max, step, defaultValue, InputProps, setValue, className } = { ...props };
+  const {
+    type,
+    value,
+    variant = "outlined",
+    label,
+    hiddenLabel = false,
+    min,
+    max,
+    step,
+    defaultValue,
+    InputProps,
+    inputProps,
+    setValue,
+    className,
+    hideSpinButton = false,
+  } = { ...props };
   const decimalPlaces = props.decimalPlaces ?? 1;
 
   const [focused, setFocused] = useState(false);
@@ -124,17 +143,18 @@ export default function NumberInput(props: Props) {
 
   return (
     <TextField
-      className={className}
+      className={`${hideSpinButton ? "hide-spin-button " : ""}${className ?? ""}`}
       type="number"
       size="small"
-      variant="outlined"
+      variant={variant}
       label={label}
+      hiddenLabel={hiddenLabel}
       value={displayValue}
       onFocus={onFocus}
       onBlur={onBlur}
       onChange={onChange}
       InputProps={InputProps}
-      inputProps={{ step }}
+      inputProps={{ ...inputProps, step }}
     />
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -19,3 +19,10 @@ body {
   color: rgb(var(--foreground-rgb));
   background: rgb(var(--background-rgb));
 }
+
+.hide-spin-button input[type="number"]::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+}
+.hide-spin-button input[type="number"] {
+  -moz-appearance: textfield;
+}

--- a/app/route/page.tsx
+++ b/app/route/page.tsx
@@ -75,6 +75,9 @@ import SyncPlayerConfigPanel from "../components/route-page/sync-player-config-p
 import { PriceContext } from "../price-provider";
 
 export default function RoutePage() {
+  const MAX_ONEGRAPH_MAX_RESTOCK = 50;
+  const MAX_ONEGRAPH_MAX_RESTOCK_SLIDER = 20;
+
   const { prices } = useContext(PriceContext);
 
   /* theme */
@@ -395,6 +398,9 @@ export default function RoutePage() {
               <Typography className="py-1">
                 来回选项开启时，算法会以最优解自动分配进货书，显示的线路是利润最大的进货书分配方法。
               </Typography>
+              <Typography className="py-1">
+                总进货次数最大{MAX_ONEGRAPH_MAX_RESTOCK}，超过{MAX_ONEGRAPH_MAX_RESTOCK_SLIDER}时请通过输入框手动输入。
+              </Typography>
             </div>
           </div>
 
@@ -418,12 +424,12 @@ export default function RoutePage() {
                   value={onegraphMaxRestock}
                   onChange={(_e, newVal) => setMaxRestock(newVal as number)}
                   min={0}
-                  max={50}
+                  max={MAX_ONEGRAPH_MAX_RESTOCK_SLIDER}
                   size="small"
                 />
                 <IconButton
                   onClick={() => {
-                    if (onegraphMaxRestock < 30) {
+                    if (onegraphMaxRestock < MAX_ONEGRAPH_MAX_RESTOCK) {
                       setMaxRestock(onegraphMaxRestock + 1);
                     }
                   }}
@@ -432,7 +438,19 @@ export default function RoutePage() {
                   <ArrowRightIcon />
                 </IconButton>
               </Box>
-              <Typography>{onegraphMaxRestock}</Typography>
+              <NumberInput
+                className="w-9"
+                hiddenLabel
+                hideSpinButton
+                variant="standard"
+                min={0}
+                max={MAX_ONEGRAPH_MAX_RESTOCK}
+                defaultValue={0}
+                type="integer"
+                value={onegraphMaxRestock}
+                inputProps={{ className: "text-center" }}
+                setValue={(newVal) => setMaxRestock(newVal)}
+              />
             </Box>
 
             <Box alignItems="center" className="mb-2 flex justify-center flex-wrap">


### PR DESCRIPTION
对于讨论提到的情况进行一点优化 https://github.com/NathanKun/resonance-columba/discussions/28#discussioncomment-9027856

自己使用的时候也有感觉不太好调整

1. 滑条 max 值太大，值间隔太密，触屏设备确实不好一步到位
2. 右边的数字没固定宽度，拖动滑条的时候容易造成布局偏移，结果滑条值也变了，在移动设备上影响尤为明显

现在优化后

1. 滑条值 max 20，毕竟一般人用的话就算双程应该也很少超过这个值，感觉够用了
2. 右边数字改为输入框，如果要超过 20 的话可以自行输入
3. <kbd>\></kbd> 按钮在超过 20 时仍然有效

顺便也发现遗留的bug，当时滑条上限 50 但 <kbd>\></kbd> 按钮判断上限是 30，导致 30 之后 <kbd>\></kbd> 无效（