### PR TITLE
feat: onegraph multi-config

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -30,7 +30,7 @@
       "login": "Tsuk1ko",
       "name": "神代綺凛",
       "avatar_url": "https://avatars.githubusercontent.com/u/24877906?v=4",
-      "profile": "https://moe.best",
+      "profile": "https://github.com/Tsuk1ko",
       "contributions": [
         "bug",
         "code",

--- a/__tests__/utils/player-config-utils.test.ts
+++ b/__tests__/utils/player-config-utils.test.ts
@@ -93,6 +93,7 @@ const validConfig1 = {
     showFatigue: true,
     showProfitPerRestock: true,
     showGeneralProfitIndex: true,
+    enableMultiConfig: true,
     displayMode: "table",
   },
   returnBargain: {

--- a/app/components/MuiThemeProvider.tsx
+++ b/app/components/MuiThemeProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { PaletteMode, ThemeProvider, createTheme } from "@mui/material";
+import { PaletteMode, ThemeProvider, createTheme, useMediaQuery } from "@mui/material";
 import { useEffect, useState } from "react";
 
 export default function MuiThemeProvider({ children }: { children: React.ReactNode }) {
@@ -16,17 +16,12 @@ export default function MuiThemeProvider({ children }: { children: React.ReactNo
 
   const [theme, setTheme] = useState(buildTheme("light"));
 
+  // https://mui.com/material-ui/customization/dark-mode/#system-preference
+  const prefersDarkMode = useMediaQuery("(prefers-color-scheme: dark)");
+
   useEffect(() => {
-    const query = window.matchMedia("(prefers-color-scheme: dark)");
-    const onChange = () => setTheme(buildTheme(query.matches ? "dark" : "light"));
-    query.addEventListener("change", onChange);
+    setTheme(buildTheme(prefersDarkMode ? "dark" : "light"));
+  }, [prefersDarkMode]);
 
-    setTheme(buildTheme(query.matches ? "dark" : "light"));
-
-    // remove the listener
-    return () => {
-      query.removeEventListener("change", onChange);
-    };
-  }, []);
   return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
 }

--- a/app/components/context-menu.tsx
+++ b/app/components/context-menu.tsx
@@ -1,0 +1,58 @@
+import { Menu } from "@mui/material";
+import { useState, forwardRef, useImperativeHandle } from "react";
+
+export interface ContextMenuRef {
+  open: (event: React.MouseEvent | Pick<React.MouseEvent, "clientX" | "clientY">) => void;
+}
+
+interface ContextMenuProps {
+  children?: React.ReactNode;
+  handleClose?: () => void;
+}
+
+export default forwardRef<ContextMenuRef, ContextMenuProps>(function ContextMenu(props, ref) {
+  const [position, setPosition] = useState<{
+    top: number;
+    left: number;
+  } | null>(null);
+
+  useImperativeHandle<ContextMenuRef, ContextMenuRef>(ref, () => {
+    return {
+      open: (event) => {
+        (event as any).preventDefault?.();
+        setPosition(
+          position === null
+            ? {
+                top: event.clientY - 6,
+                left: event.clientX + 2,
+              }
+            : null
+        );
+      },
+    };
+  });
+
+  const handleClose = () => {
+    setPosition(null);
+    props.handleClose?.();
+  };
+
+  const handleMenuClick = ({ target }: React.MouseEvent) => {
+    if (target instanceof HTMLElement && target.tagName === "LI") {
+      handleClose();
+    }
+  };
+
+  return (
+    <Menu
+      open={position !== null}
+      onClose={handleClose}
+      anchorReference="anchorPosition"
+      anchorPosition={position ?? undefined}
+      onClick={handleMenuClick}
+      onContextMenu={(e) => e.preventDefault()}
+    >
+      {props.children}
+    </Menu>
+  );
+});

--- a/app/components/prices-table/multiple-select.tsx
+++ b/app/components/prices-table/multiple-select.tsx
@@ -10,12 +10,9 @@ export default function MultipleSelect(props: any) {
   const internalHandleChange = (event: any) => {
     const selected = event.target.value;
     if (selected.includes("allBtn")) {
-      const allSelectedBeforeChange = allOptions.length === selectedOptions.length;
-      if (allSelectedBeforeChange) {
-        handleChange([]);
-      } else {
-        handleChange(allOptions);
-      }
+      handleChange(allOptions);
+    } else if (selected.includes("noneBtn")) {
+      handleChange([]);
     } else {
       handleChange(selected);
     }
@@ -59,8 +56,11 @@ export default function MultipleSelect(props: any) {
             {option}
           </MenuItem>
         ))}
-        <MenuItem key="allBtn" value="allBtn">
-          {allOptions.length === selectedOptions.length ? "全取消" : "全选"}
+        <MenuItem key="noneBtn" value="noneBtn" disabled={!selectedOptions.length}>
+          全取消
+        </MenuItem>
+        <MenuItem key="allBtn" value="allBtn" disabled={allOptions.length === selectedOptions.length}>
+          全选
         </MenuItem>
       </Select>
     </FormControl>

--- a/app/components/prices-table/prices-table.tsx
+++ b/app/components/prices-table/prices-table.tsx
@@ -9,6 +9,7 @@ import { Trend } from "@/interfaces/trend";
 import { calculateProfit, highestProfitCity, isCraftOnlyProduct } from "@/utils/price-utils";
 import PaletteIcon from "@mui/icons-material/Palette";
 import SyncAltIcon from "@mui/icons-material/SyncAlt";
+import ArrowRightAltIcon from "@mui/icons-material/ArrowRightAlt";
 import { IconButton, alpha, darken, lighten, useTheme } from "@mui/material";
 import {
   MRT_Cell,
@@ -30,9 +31,10 @@ import VariationInput from "./variation-input";
 
 export default function PricesTable() {
   const { prices, setPrice } = useContext(PriceContext);
-  const { selectedCities, setSourceCities, setTargetCities, switchSourceAndTargetCities } = useSelectedCities({
-    localStorageKey: "selectedCities",
-  });
+  const { selectedCities, setSourceCities, setTargetCities, switchSourceAndTargetCities, copySourceToTargetCities } =
+    useSelectedCities({
+      localStorageKey: "selectedCities",
+    });
   const theme = useTheme();
 
   const baseBackgroundColor =
@@ -436,6 +438,9 @@ export default function PricesTable() {
         <IconButton onClick={switchSourceAndTargetCities} size="small">
           <SyncAltIcon />
         </IconButton>
+        <IconButton onClick={copySourceToTargetCities} size="small">
+          <ArrowRightAltIcon />
+        </IconButton>
         <IconButton onClick={onTrendCellColorButtonClick} size="small">
           <PaletteIcon />
         </IconButton>
@@ -448,6 +453,7 @@ export default function PricesTable() {
     setSourceCities,
     setTargetCities,
     switchSourceAndTargetCities,
+    copySourceToTargetCities,
   ]);
 
   const table = useMaterialReactTable({

--- a/app/components/route-page/onegraph-multi-config-select.tsx
+++ b/app/components/route-page/onegraph-multi-config-select.tsx
@@ -1,0 +1,211 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  Button,
+  ButtonGroup,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  MenuItem,
+  Popover,
+  TextField,
+  Typography,
+} from "@mui/material";
+import useOnegraphMultiConfig, { OnegraphMultiConfigItem } from "@/hooks/useOnegraphMultiConfig";
+import type { PlayerConfig } from "@/interfaces/player-config";
+import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
+import ContextMenu, { ContextMenuRef } from "../context-menu";
+
+interface OnegraphMultiConfigSelectProps {
+  playerConfig: PlayerConfig;
+  onPlayerConfigChange: (field: string, value: any) => void;
+}
+
+export default function OnegraphMultiConfigSelect({
+  playerConfig,
+  onPlayerConfigChange,
+}: OnegraphMultiConfigSelectProps) {
+  const menuRef = useRef<ContextMenuRef>(null);
+  const menuActiveConfig = useRef<OnegraphMultiConfigItem>();
+  const longPressTimer = useRef<NodeJS.Timeout>();
+
+  const { multiConfig, addMultiConfig, removeMultiConfig, applyMultiConfig, renameMultiConfig, updateMultiConfig } =
+    useOnegraphMultiConfig({
+      playerConfig,
+      onPlayerConfigChange,
+    });
+  const [renameOldName, setRenameOldName] = useState<string | null>(null);
+  const [openHelp, setOpenHelp] = useState(false);
+  const [helpAnchorEl, setHelpAnchorEl] = useState<HTMLButtonElement | null>(null);
+
+  const handleContextMenu = (e: Parameters<ContextMenuRef["open"]>["0"], config: OnegraphMultiConfigItem) => {
+    menuActiveConfig.current = config;
+    menuRef.current?.open(e);
+  };
+
+  const handleStartLongPress = (e: React.TouchEvent, config: OnegraphMultiConfigItem) => {
+    e.preventDefault();
+    longPressTimer.current = setTimeout(() => {
+      handleContextMenu(e.touches[0], config);
+    }, 400);
+  };
+
+  const handleEndLongPress = () => {
+    clearTimeout(longPressTimer.current);
+    longPressTimer.current = undefined;
+  };
+
+  const handleRemoveConfig = () => {
+    if (!menuActiveConfig.current) return;
+    removeMultiConfig(menuActiveConfig.current);
+  };
+
+  const handleOpenRenameDialog = () => {
+    if (!menuActiveConfig.current) return;
+    setRenameOldName(menuActiveConfig.current.name);
+  };
+
+  const handleRename = (name: string) => {
+    if (!menuActiveConfig.current) return;
+    renameMultiConfig(menuActiveConfig.current, name);
+  };
+
+  const handleUpdateConfig = () => {
+    if (!menuActiveConfig.current) return;
+    updateMultiConfig(menuActiveConfig.current);
+  };
+
+  const handleOpenHelp = (e: React.MouseEvent<HTMLButtonElement>) => {
+    setHelpAnchorEl(e.currentTarget);
+    setOpenHelp(true);
+  };
+
+  return (
+    <>
+      <ButtonGroup className="overflow-x-auto max-sm:mx-4" variant="outlined">
+        {multiConfig.map((config) => (
+          <Button
+            className="whitespace-nowrap shrink-0"
+            key={config.id}
+            onClick={() => applyMultiConfig(config)}
+            onContextMenu={(e) => handleContextMenu(e, config)}
+            onTouchStart={(e) => handleStartLongPress(e, config)}
+            onTouchCancel={handleEndLongPress}
+            onTouchEnd={handleEndLongPress}
+            sx={{ textTransform: "none" }}
+          >
+            {config.name}
+          </Button>
+        ))}
+      </ButtonGroup>
+      <div className="flex justify-center flex-nowrap -order-1 sm:-order-none">
+        <Button className="ml-4 whitespace-nowrap" variant="text" onClick={addMultiConfig}>
+          添加配置
+        </Button>
+        <IconButton className="mx-4" size="small" onClick={handleOpenHelp}>
+          <HelpOutlineIcon />
+        </IconButton>
+      </div>
+      <ContextMenu ref={menuRef}>
+        <MenuItem onClick={handleUpdateConfig}>更新</MenuItem>
+        <MenuItem onClick={handleOpenRenameDialog}>重命名</MenuItem>
+        <MenuItem onClick={handleRemoveConfig}>删除</MenuItem>
+      </ContextMenu>
+      <ConfigRenameDialog
+        oldName={renameOldName}
+        handleRename={handleRename}
+        handleClose={() => setRenameOldName(null)}
+      />
+      <Popover
+        open={openHelp}
+        anchorEl={helpAnchorEl}
+        onClose={() => setOpenHelp(false)}
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "center",
+        }}
+        transformOrigin={{
+          vertical: "top",
+          horizontal: "center",
+        }}
+      >
+        <Typography className="m-4">
+          点击“添加配置”后，当前一图流的配置会被保存到一个新配置中，点击某个配置可以重新应用该配置。
+        </Typography>
+        <Typography className="m-4">
+          右击（移动端长按）某个配置可弹出操作菜单进行“重命名”、“删除”等操作，“更新”指的是将当前一图流配置更新到该配置。
+        </Typography>
+      </Popover>
+    </>
+  );
+}
+
+function ConfigRenameDialog({
+  oldName,
+  handleRename,
+  handleClose,
+}: {
+  oldName: string | null;
+  handleRename: (name: string) => void;
+  handleClose: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [newName, setNewName] = useState("");
+
+  const handleDialogClose = () => {
+    setOpen(false);
+    handleClose();
+  };
+
+  useEffect(() => {
+    if (typeof oldName === "string") {
+      setOpen(true);
+      setNewName(oldName);
+    }
+  }, [oldName]);
+
+  const handleInputChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
+    setNewName(event.target.value);
+  };
+
+  const handleConfirmRename = () => {
+    if (newName) {
+      handleRename(newName);
+      handleDialogClose();
+    }
+  };
+
+  const inputRef = useRef<HTMLElement>(null);
+
+  // auto focus
+  useEffect(() => {
+    if (!open) return;
+    setTimeout(() => {
+      inputRef.current?.focus?.();
+    });
+  }, [open]);
+
+  return (
+    <Dialog open={open} onClose={handleDialogClose}>
+      <DialogTitle>配置重命名</DialogTitle>
+      <DialogContent>
+        <TextField
+          inputRef={inputRef}
+          margin="dense"
+          hiddenLabel
+          fullWidth
+          variant="standard"
+          defaultValue={oldName}
+          onChange={handleInputChange}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleDialogClose}>取消</Button>
+        <Button disabled={!newName || newName === oldName} onClick={handleConfirmRename}>
+          确定
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/app/components/route-page/tabs/onegraph-tab.tsx
+++ b/app/components/route-page/tabs/onegraph-tab.tsx
@@ -53,6 +53,7 @@ import StatedIconButton from "../StatedIconButton";
 import BargainInputs from "../bargain-inputs";
 import NumberInput from "../number-input";
 import OneGraphRouteDialog from "../onegraph-route-dialog";
+import OnegraphMultiConfigSelect from "../onegraph-multi-config-select";
 
 interface OnegraphTabProps {
   playerConfig: PlayerConfig;
@@ -72,6 +73,7 @@ export default function OnegraphTab(props: OnegraphTabProps) {
     maxRestock: onegraphMaxRestock,
     showFatigue: onegraphShowFatigue,
     showGeneralProfitIndex: onegraphShowGeneralProfitIndex,
+    enableMultiConfig: onegraphEnableMultiConfig,
     displayMode: onegraphDisplayMode,
   } = playerConfig.onegraph;
 
@@ -107,6 +109,8 @@ export default function OnegraphTab(props: OnegraphTabProps) {
 
   const setOnegraphShowGeneralProfitIndex = (value: boolean) =>
     oneOnegraphPlayerConfigChange("showGeneralProfitIndex", value);
+
+  const setOnegraphEnableMultiConfig = (value: boolean) => oneOnegraphPlayerConfigChange("enableMultiConfig", value);
 
   const setOnegraphDisplayMode = (value: "table" | "list") => oneOnegraphPlayerConfigChange("displayMode", value);
 
@@ -408,6 +412,19 @@ export default function OnegraphTab(props: OnegraphTabProps) {
             }
             label={<Typography>显示综合参考利润</Typography>}
           />
+
+          <FormControlLabel
+            className="w-30"
+            control={
+              <Switch
+                checked={onegraphEnableMultiConfig}
+                onChange={(e) => {
+                  setOnegraphEnableMultiConfig(e.target.checked);
+                }}
+              />
+            }
+            label={<Typography>启用多配置</Typography>}
+          />
         </Box>
 
         <Box alignItems="center" className="mb-2 flex justify-center flex-wrap">
@@ -452,6 +469,14 @@ export default function OnegraphTab(props: OnegraphTabProps) {
           />
         </Box>
       </Box>
+
+      {onegraphEnableMultiConfig ? (
+        <Box alignItems="center" className="mb-2 flex justify-center flex-wrap">
+          <Typography className="m-4 grow sm:grow-0 -order-2 whitespace-nowrap">配置</Typography>
+          <OnegraphMultiConfigSelect playerConfig={playerConfig} onPlayerConfigChange={onPlayerConfigChange} />
+        </Box>
+      ) : null}
+
       <Paper className="w-full shadow-xl rounded-lg backdrop-blur-lg max-w-6xl mx-auto my-4 dark:bg-neutral-900 ">
         {/* display mode toggle & disable cell color btn */}
         <Box className="flex justify-between items-center">

--- a/hooks/useColumnVisibilityOverride.ts
+++ b/hooks/useColumnVisibilityOverride.ts
@@ -1,42 +1,13 @@
 import { CITIES } from "@/data/Cities";
-import { useCallback, useEffect, useMemo, useState } from "react";
-
-const isServer = typeof window === "undefined";
+import { useMemo } from "react";
+import { useLocalStorage } from "usehooks-ts";
 
 export default function useColumnVisibilityOverride(targetCities: string[]) {
-  const localStorageKey = "columnVisibilityOverride";
-  const [manualVisibilityOverride, setManualVisibilityOverride] = useState<{ [key: string]: boolean }>({});
-
-  // LC related
-  const initialize = () => {
-    if (isServer) {
-      return {};
-    }
-    try {
-      const data = localStorage.getItem(localStorageKey);
-      return data ? JSON.parse(data) : {};
-    } catch (e) {
-      console.error(e);
-      return {};
-    }
-  };
-
-  const updateColumnVisibilityOverrideLsAndState = useCallback(
-    (newSettings: any) => {
-      const newStr = JSON.stringify(newSettings);
-      localStorage.setItem(localStorageKey, newStr);
-      setManualVisibilityOverride(newSettings);
-    },
-    [localStorageKey]
+  const [manualVisibilityOverride, setManualVisibilityOverride] = useLocalStorage<{ [key: string]: boolean }>(
+    "columnVisibilityOverride",
+    {},
+    { initializeWithValue: false }
   );
-
-  /* prevents hydration error so that state is only initialized after server is defined */
-  useEffect(() => {
-    if (!isServer) {
-      setManualVisibilityOverride(initialize());
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   // col visibility calculation
   const baseColumnVisibility = useMemo(() => {
@@ -69,7 +40,7 @@ export default function useColumnVisibilityOverride(targetCities: string[]) {
 
   const onColumnVisibilityChange = (updater: any): void => {
     const newSettings = updater();
-    updateColumnVisibilityOverrideLsAndState({ ...manualVisibilityOverride, ...newSettings });
+    setManualVisibilityOverride({ ...manualVisibilityOverride, ...newSettings });
   };
 
   return { columnVisibility, onColumnVisibilityChange };

--- a/hooks/useOnegraphMultiConfig.ts
+++ b/hooks/useOnegraphMultiConfig.ts
@@ -1,0 +1,94 @@
+import { useLocalStorage } from "usehooks-ts";
+import { nanoid } from "nanoid";
+import type { PlayerConfig } from "@/interfaces/player-config";
+import { pickBy, without } from "@/utils/tiny-lodash";
+
+// Modify this if more properties need to be save in the future
+const playerConfigPickKeys = ["bargain", "returnBargain", "onegraph"] as const;
+
+export interface OnegraphMultiConfigItem {
+  id: string;
+  name: string;
+  data: Pick<PlayerConfig, (typeof playerConfigPickKeys)[number]>;
+}
+
+export type OnegraphMultiConfig = OnegraphMultiConfigItem[];
+
+interface UseOnegraphMultiConfigOptions {
+  playerConfig: PlayerConfig;
+  onPlayerConfigChange: (field: string, value: any) => void;
+}
+
+export default function useOnegraphMultiConfig({ playerConfig, onPlayerConfigChange }: UseOnegraphMultiConfigOptions) {
+  const [multiConfig, setMultiConfig] = useLocalStorage<OnegraphMultiConfig>("onegraphMultiConfig", [], {
+    initializeWithValue: false,
+  });
+
+  const getNewConfigName = () => {
+    const reg = /^配置 (\d+)$/;
+    try {
+      const maxOrder = Math.max(
+        0,
+        ...multiConfig.map(({ name }) => {
+          const match = reg.exec(name);
+          const num = Number(match?.[1] ?? 0);
+          return num;
+        })
+      );
+      return `配置 ${maxOrder + 1}`;
+    } catch {
+      return `配置 ${multiConfig.length + 1}`;
+    }
+  };
+
+  const addMultiConfig = () => {
+    const newConfig: OnegraphMultiConfigItem = {
+      id: nanoid(),
+      name: getNewConfigName(),
+      data: pickBy(playerConfig, playerConfigPickKeys),
+    };
+    setMultiConfig([...multiConfig, newConfig]);
+  };
+
+  const removeMultiConfig = (config: OnegraphMultiConfigItem) => {
+    setMultiConfig(without(multiConfig, config));
+  };
+
+  const applyMultiConfig = (config: OnegraphMultiConfigItem) => {
+    Object.entries(config.data).forEach(([key, val]) => {
+      const oldConfig = playerConfig[key as keyof OnegraphMultiConfigItem["data"]];
+      if (typeof oldConfig === "object" && !Array.isArray(oldConfig)) {
+        onPlayerConfigChange(key, { ...oldConfig, ...val });
+      } else {
+        onPlayerConfigChange(key, val);
+      }
+    });
+  };
+
+  const renameMultiConfig = (config: OnegraphMultiConfigItem, newName: string) => {
+    setMultiConfig(
+      multiConfig.map((item) => {
+        if (item !== config) return item;
+        return { ...config, name: newName };
+      })
+    );
+  };
+
+  const updateMultiConfig = (config: OnegraphMultiConfigItem) => {
+    setMultiConfig(
+      multiConfig.map((item) => {
+        if (item !== config) return item;
+        return { ...config, data: pickBy(playerConfig, playerConfigPickKeys) };
+      })
+    );
+  };
+
+  return {
+    multiConfig,
+    addMultiConfig,
+    removeMultiConfig,
+    applyMultiConfig,
+    renameMultiConfig,
+    updateMultiConfig,
+  };
+}

--- a/hooks/useSelectedCities.ts
+++ b/hooks/useSelectedCities.ts
@@ -1,54 +1,33 @@
 import { CITIES, CityName } from "@/data/Cities";
 import { SelectedCities } from "@/interfaces/prices-table";
 import { useCallback, useEffect, useState } from "react";
-
-const isServer = typeof window === "undefined";
+import { useLocalStorage } from "usehooks-ts";
 
 export default function useSelectedCities(props: { localStorageKey: string }) {
-  const { localStorageKey } = props;
   const initialSelectedCities = { sourceCities: [CITIES[0]], targetCities: [CITIES[1]] };
 
-  const [selectedCities, setSelectedCities] = useState<SelectedCities>(initialSelectedCities);
-
-  const initialize = () => {
-    if (isServer) {
-      return initialSelectedCities;
+  const [selectedCities, setSelectedCities] = useLocalStorage<SelectedCities>(
+    props.localStorageKey,
+    initialSelectedCities,
+    {
+      initializeWithValue: false,
     }
-    const selectedCitiesStr = localStorage.getItem(localStorageKey);
-    return selectedCitiesStr ? JSON.parse(selectedCitiesStr) : initialSelectedCities;
-  };
-
-  /* prevents hydration error so that state is only initialized after server is defined */
-  useEffect(() => {
-    if (!isServer) {
-      setSelectedCities(initialize());
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const updateSelectedCitiesLsAndState = useCallback(
-    (newSelectedCities: SelectedCities) => {
-      const newStr = JSON.stringify(newSelectedCities);
-      localStorage.setItem(localStorageKey, newStr);
-      setSelectedCities(newSelectedCities);
-    },
-    [localStorageKey]
   );
 
   const setSourceCities = useCallback(
     (selected: CityName[]) => {
       const newSelectedCities = { ...selectedCities, sourceCities: selected };
-      updateSelectedCitiesLsAndState(newSelectedCities);
+      setSelectedCities(newSelectedCities);
     },
-    [selectedCities, updateSelectedCitiesLsAndState]
+    [selectedCities, setSelectedCities]
   );
 
   const setTargetCities = useCallback(
     (selected: CityName[]) => {
       const newSelectedCities = { ...selectedCities, targetCities: selected };
-      updateSelectedCitiesLsAndState(newSelectedCities);
+      setSelectedCities(newSelectedCities);
     },
-    [selectedCities, updateSelectedCitiesLsAndState]
+    [selectedCities, setSelectedCities]
   );
 
   const switchSourceAndTargetCities = useCallback(() => {
@@ -56,8 +35,8 @@ export default function useSelectedCities(props: { localStorageKey: string }) {
       sourceCities: selectedCities.targetCities,
       targetCities: selectedCities.sourceCities,
     };
-    updateSelectedCitiesLsAndState(newSelectedCities);
-  }, [selectedCities, updateSelectedCitiesLsAndState]);
+    setSelectedCities(newSelectedCities);
+  }, [selectedCities, setSelectedCities]);
 
   return { selectedCities, setSourceCities, setTargetCities, switchSourceAndTargetCities };
 }

--- a/hooks/useSelectedCities.ts
+++ b/hooks/useSelectedCities.ts
@@ -38,5 +38,13 @@ export default function useSelectedCities(props: { localStorageKey: string }) {
     setSelectedCities(newSelectedCities);
   }, [selectedCities, setSelectedCities]);
 
-  return { selectedCities, setSourceCities, setTargetCities, switchSourceAndTargetCities };
+  const copySourceToTargetCities = useCallback(() => {
+    const newSelectedCities = {
+      sourceCities: selectedCities.sourceCities,
+      targetCities: selectedCities.sourceCities,
+    };
+    setSelectedCities(newSelectedCities);
+  }, [selectedCities, setSelectedCities]);
+
+  return { selectedCities, setSourceCities, setTargetCities, switchSourceAndTargetCities, copySourceToTargetCities };
 }

--- a/interfaces/player-config.ts
+++ b/interfaces/player-config.ts
@@ -39,6 +39,7 @@ export interface PlayerConfigOnegraph {
    */
   showProfitPerRestock: boolean;
   showGeneralProfitIndex: boolean;
+  enableMultiConfig: boolean;
   displayMode: "table" | "list";
 }
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "react-dom": "18.2.0",
     "resonance-data-columba": "^1.1.39",
     "tailwindcss": "3.4.3",
-    "typescript": "5.4.5"
+    "typescript": "5.4.5",
+    "usehooks-ts": "^3.1.0"
   },
   "devDependencies": {
     "@testing-library/react": "^15.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       typescript:
         specifier: 5.4.5
         version: 5.4.5
+      usehooks-ts:
+        specifier: ^3.1.0
+        version: 3.1.0(react@18.2.0)
     devDependencies:
       '@testing-library/react':
         specifier: ^15.0.2
@@ -2436,6 +2439,9 @@ packages:
   lodash.clonedeep@4.5.0:
     resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
 
+  lodash.debounce@4.0.8:
+    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
+
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
 
@@ -3423,6 +3429,12 @@ packages:
 
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+
+  usehooks-ts@3.1.0:
+    resolution: {integrity: sha512-bBIa7yUyPhE1BCc0GmR96VU/15l/9gP1Ch5mYdLcFBaFGQsdmXkvjV0TtOqW1yUd6VjIwDunm+flSciCQXujiw==}
+    engines: {node: '>=16.15.0'}
+    peerDependencies:
+      react: ^16.8.0  || ^17 || ^18
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -6326,6 +6338,8 @@ snapshots:
 
   lodash.clonedeep@4.5.0: {}
 
+  lodash.debounce@4.0.8: {}
+
   lodash.includes@4.3.0: {}
 
   lodash.isboolean@3.0.3: {}
@@ -7367,6 +7381,11 @@ snapshots:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
+
+  usehooks-ts@3.1.0(react@18.2.0):
+    dependencies:
+      lodash.debounce: 4.0.8
+      react: 18.2.0
 
   util-deprecate@1.0.2: {}
 

--- a/utils/player-config-utils.ts
+++ b/utils/player-config-utils.ts
@@ -107,6 +107,7 @@ export const isValidPlayerConfig = (config: any) => {
             "showFatigue",
             "showProfitPerRestock",
             "showGeneralProfitIndex",
+            "enableMultiConfig",
             "displayMode",
           ].includes(key)
       ).length > 0
@@ -137,6 +138,10 @@ export const isValidPlayerConfig = (config: any) => {
     }
 
     if (onegraph.showGeneralProfitIndex !== undefined && typeof onegraph.showGeneralProfitIndex !== "boolean") {
+      return false;
+    }
+
+    if (onegraph.enableMultiConfig !== undefined && typeof onegraph.enableMultiConfig !== "boolean") {
       return false;
     }
 
@@ -240,6 +245,7 @@ export const INITIAL_PLAYER_CONFIG: PlayerConfig = {
     showFatigue: false,
     showProfitPerRestock: false,
     showGeneralProfitIndex: false,
+    enableMultiConfig: false,
     displayMode: "table",
   },
   productUnlockStatus: {},

--- a/utils/tiny-lodash.ts
+++ b/utils/tiny-lodash.ts
@@ -1,0 +1,14 @@
+// Simply implement some commonly used [lodash](https://www.npmjs.com/package/lodash-es) methods.
+// I'm not sure if this package should be installed (considering that it is not small and tree-shaking requires plugins), so I will implement it simply here for now.
+// If it needs to be installed in the future, it can directly replace this file.
+// By @Tsuk1ko
+
+export const pickBy = <T extends Record<string, any>, U extends keyof T>(obj: T, keys: readonly U[]): Pick<T, U> => {
+  const keySet = new Set(keys);
+  return Object.fromEntries(Object.entries(obj).filter(([key]) => keySet.has(key as any))) as any;
+};
+
+export const without = <T = any>(array: T[], ...values: T[]) => {
+  const valueSet = new Set(values);
+  return array.filter((item) => !valueSet.has(item));
+};


### PR DESCRIPTION
## 主要更改

给一图流增加“多配置”功能，可以在用户自定义添加的多种配置间切换，免得频繁手动修改进货书和砍抬价等配置

https://github.com/NathanKun/resonance-columba/assets/24877906/205e071e-025a-40a4-840e-d5836694dec9

“启用多配置”开关仅用于控制是否显示多配置UI，加到 playerConfig 中，以免不需要使用的人被UI打扰

多配置数据独立储存，没有放入 playerConfig，不参与配置同步

提供了说明

![image](https://github.com/NathanKun/resonance-columba/assets/24877906/c3a3d8dd-e0d7-466f-bc30-d43224df316d)

## 其他更改

1. 暗色模式检测直接使用 mui 官方提供的 useMediaQuery，不用造轮子 https://mui.com/material-ui/customization/dark-mode/#system-preference
2. localStorage 的响应式更新使用 [usehooks-ts](https://usehooks-ts.com/) 实现的 [useLocalStorage](https://usehooks-ts.com/react-hook/use-local-storage)，不用造轮子，而且处理了多页面时 localStorage 的同步问题，**但没在生产环境验证过，vercel 的 mr 预览出来后希望仔细验证下有无问题**
3. 城市多选常驻“全取消”和“全选”，因为有时候想改成其他的可以直接全取消再点会方便点 ![chrome_fDifka02t7](https://github.com/NathanKun/resonance-columba/assets/24877906/3c522811-3861-4992-ab05-f16631aca1d5)
4. 数据表格增加一个拷贝原产地到目标城市按钮 ![chrome_Pyq2U0V2yx](https://github.com/NathanKun/resonance-columba/assets/24877906/bd91d115-f0d1-430a-bf5f-cb41547a2eb1)
