### PR TITLE
feat: onegraph sticky column header

### DIFF
--- a/app/components/route-page/tabs/onegraph-tab.tsx
+++ b/app/components/route-page/tabs/onegraph-tab.tsx
@@ -525,18 +525,50 @@ export default function OnegraphTab(props: OnegraphTabProps) {
                 "& .onegraph-cell-fromcity-cityname": {
                   width: "7rem",
                 },
+                "& .sticky-cell": {
+                  position: "sticky",
+                  backgroundColor: "#fff",
+                  zIndex: 2,
+                },
+                "& th.sticky-cell": {
+                  top: 0,
+                },
+                "& td.sticky-cell": {
+                  left: 0,
+                },
+                "& .sticky-cell::before": {
+                  content: '""',
+                  display: "block",
+                  position: "absolute",
+                  border: "solid grey",
+                  pointerEvents: "none",
+                },
+                "& th.sticky-cell::before": {
+                  bottom: -1,
+                  left: 0,
+                  right: 0,
+                  height: 0,
+                  borderWidth: "0 0 1px 0",
+                },
+                "& td.sticky-cell::before": {
+                  top: 0,
+                  bottom: 0,
+                  right: -1,
+                  width: 0,
+                  borderWidth: "0 1px 0 0",
+                },
               }}
             >
               <TableHead>
                 {/** header 1 - spanning 终点 cell */}
                 <TableRow>
-                  <TableCell align="center" colSpan={CITIES.length + 2}>
+                  <TableCell colSpan={2} rowSpan={2}></TableCell>
+                  <TableCell align="center" colSpan={CITIES.length}>
                     终点
                   </TableCell>
                 </TableRow>
                 {/** header 2 - city cells */}
                 <TableRow>
-                  <TableCell colSpan={2}></TableCell>
                   {CITIES.map((city) => (
                     <TableCell key={`onegraph-${city}`} align="center">
                       {city}
@@ -549,13 +581,13 @@ export default function OnegraphTab(props: OnegraphTabProps) {
                   <TableRow key={`onegraph-row-${fromCity}`}>
                     {/** spaning 起点 cell */}
                     {index === 0 && (
-                      <TableCell className="onegraph-cell-fromcity-source" rowSpan={CITIES.length}>
+                      <TableCell className="onegraph-cell-fromcity-source text-center" rowSpan={CITIES.length}>
                         起点
                       </TableCell>
                     )}
 
                     {/** city name */}
-                    <TableCell className="onegraph-cell-fromcity-cityname min-w-14">{fromCity}</TableCell>
+                    <TableCell className="onegraph-cell-fromcity-cityname sticky-cell min-w-14">{fromCity}</TableCell>
 
                     {/** profit cells */}
                     {CITIES.map((toCity) => {

--- a/app/globals.css
+++ b/app/globals.css
@@ -18,6 +18,7 @@
 body {
   color: rgb(var(--foreground-rgb));
   background: rgb(var(--background-rgb));
+  padding-bottom: env(safe-area-inset-bottom);
 }
 
 .hide-spin-button input[type="number"]::-webkit-inner-spin-button {


### PR DESCRIPTION
给一图流表格左侧表头增加 sticky 以方便手机端查看

其实本来想给顶部 header 也加上的（并且我也预留了给顶部使用的 style），但是由于 sticky 的机制【作用于离它最近的一个拥有“滚动机制”的祖先上】导致效果不能令人满意

我理想中的效果是可以作用于 body 上，但这就必须要使 `<TableContainer>` `overflow: visible`，此时如果表格需要横向滚动那么就会非常难看，因为将会变成整个 body 可以横向滚动

还有一种选择是给 `<TableContainer>` `max-height: 100vh`，此时至少不会难看了，但这会弄出双层纵向滚动，body 和 table 都可以纵向滚动，滚动体验很差

想做到完美的体验可能必须依赖 js 逻辑，但是这样就太复杂了，感觉根本不值得，而且就目前的城市量和移动设备纵向高度应该是完全显示的下的，就先算了😢

![chrome_fplReqG8RQ](https://github.com/NathanKun/resonance-columba/assets/24877906/d2be875c-42a5-4372-a409-2c731b2ca1d6)
